### PR TITLE
[DM-23265] Mismatch of variables for external URLs

### DIFF
--- a/jupyterhubutils/_version.py
+++ b/jupyterhubutils/_version.py
@@ -1,5 +1,5 @@
 '''
 Version information.
 '''
-version_info = (0, 14, 0)
+version_info = (0, 14, 1)
 __version__ = '.'.join(map(str, version_info))

--- a/jupyterhubutils/config/lsstconfig.py
+++ b/jupyterhubutils/config/lsstconfig.py
@@ -104,11 +104,11 @@ class LSSTConfig(metaclass=Singleton):
         self.tap_route = os.getenv('TAP_ROUTE') or '/api/tap'
         self.soda_route = os.getenv('SODA_ROUTE') or '/api/image/soda'
         self.workflow_route = os.getenv('WORKFLOW_ROUTE') or '/workflow'
-        self.external_firefly_route = os.getenv('EXTERNAL_FIREFLY_ROUTE')
-        self.external_js9_route = os.getenv('EXTERNAL_JS9_ROUTE')
-        self.external_api_route = os.getenv('EXTERNAL_API_ROUTE')
-        self.external_tap_route = os.getenv('EXTERNAL_TAP_ROUTE')
-        self.external_soda_route = os.getenv('EXTERNAL_SODA_ROUTE')
+        self.external_firefly_url = os.getenv('EXTERNAL_FIREFLY_URL')
+        self.external_js9_url = os.getenv('EXTERNAL_JS9_URL')
+        self.external_api_url = os.getenv('EXTERNAL_API_URL')
+        self.external_tap_url = os.getenv('EXTERNAL_TAP_URL')
+        self.external_soda_url = os.getenv('EXTERNAL_SODA_URL')
         self.external_workflow_route = os.getenv('EXTERNAL_WORKFLOW_ROUTE')
         self.auto_repo_urls = os.getenv('AUTO_REPO_URLS')
         # Prepuller settings

--- a/jupyterhubutils/lsstmgr/envmanager.py
+++ b/jupyterhubutils/lsstmgr/envmanager.py
@@ -42,11 +42,11 @@ class LSSTEnvironmentManager(LoggableChild):
         env['TAP_ROUTE'] = cfg.tap_route
         env['SODA_ROUTE'] = cfg.soda_route
         env['WORKFLOW_ROUTE'] = cfg.workflow_route
-        env['EXTERNAL_FIREFLY_ROUTE'] = cfg.external_firefly_route
-        env['EXTERNAL_JS9_ROUTE'] = cfg.external_js9_route
-        env['EXTERNAL_API_ROUTE'] = cfg.external_api_route
-        env['EXTERNAL_TAP_ROUTE'] = cfg.external_tap_route
-        env['EXTERNAL_SODA_ROUTE'] = cfg.external_soda_route
+        env['EXTERNAL_FIREFLY_URL'] = cfg.external_firefly_url
+        env['EXTERNAL_JS9_URL'] = cfg.external_js9_url
+        env['EXTERNAL_API_URL'] = cfg.external_api_url
+        env['EXTERNAL_TAP_URL'] = cfg.external_tap_url
+        env['EXTERNAL_SODA_URL'] = cfg.external_soda_url
         env['EXTERNAL_WORKFLOW_ROUTE'] = cfg.external_workflow_route
         env['AUTO_REPO_URLS'] = cfg.auto_repo_urls
         # Now clean up the env hash by removing any keys with empty values


### PR DESCRIPTION
They were called routes, but they're URLs, so the environment variables
are supposed to be _URL.  So while the chart and helm was working, and
injecting it into the hub, the hub wasn't injecting this into the lab
containers.