### PR TITLE
[DM-23677] Add additional Argo CD annotations

### DIFF
--- a/jupyterhubutils/lsstmgr/namespacemanager.py
+++ b/jupyterhubutils/lsstmgr/namespacemanager.py
@@ -35,7 +35,11 @@ class LSSTNamespaceManager(LoggableChild):
         ns = client.V1Namespace(
             metadata=client.V1ObjectMeta(
                 name=namespace,
-                labels={'argocd.argoproj.io/instance': 'nublado-users'}))
+                labels={'argocd.argoproj.io/instance': 'nublado-users'},
+                annotations={
+                    'argocd.argoproj.io/compare-options': 'IgnoreExtraneous',
+                    'argocd.argoproj.io/sync-options': 'Prune=false',
+                }))
         try:
             self.log.info("Attempting to create namespace '%s'" % namespace)
             api.create_namespace(ns)

--- a/jupyterhubutils/lsstmgr/workflowmanager.py
+++ b/jupyterhubutils/lsstmgr/workflowmanager.py
@@ -268,6 +268,12 @@ class LSSTWorkflow(Workflow):
                     anno[skey] = chunk
                     jdx = jdx+1
             idx = idx + 1
+
+        # Add annotations telling Argo CD to not prune these resources or to
+        # count them against the sync state.
+        anno['argocd.argoproj.io/compare-options'] = 'IgnoreExtraneous'
+        anno['argocd.argoproj.io/sync-options'] = 'Prune=false'
+
         return anno
 
     @template

--- a/jupyterhubutils/spawner/lsstspawner.py
+++ b/jupyterhubutils/spawner/lsstspawner.py
@@ -165,8 +165,10 @@ class LSSTSpawner(MultiNamespacedKubeSpawner):
             cmd = ctrs[0].args or ctrs[0].command
         # That should be it from the standard get_pod_manifest
         # Now we finally need all that data we have been managing.
-        # Add label for ArgoCD management.
+        # Add label and annotations for ArgoCD management.
         labels['argocd.argoproj.io/instance'] = 'nublado-users'
+        annotations['argocd.argoproj.io/compare-options'] = 'IgnoreExtraneous'
+        annotations['argocd.argoproj.io/sync-options'] = 'Prune=false'
         cfg = self.lsst_mgr.config
         em = self.lsst_mgr.env_mgr
         am = self.lsst_mgr.auth_mgr


### PR DESCRIPTION
Add annotations to dynamically created resources telling Argo CD
to not count them against the sync state of the containing
application and to not prune them.